### PR TITLE
ビルドエラー修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,8 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
+# OpenNext
+.open-next
+
 # IDE
 .idea

--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,6 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
-  output: 'export',
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## 概要

`next.config.js`で`output: 'export'`にしてると`npx open-next build`でエラーになる。
恐らく`.next/standalone`配下に`.next/server`が出力されないため？
