### PR TITLE
modern-css-resetのインストール

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "eslint-plugin-storybook": "^0.6.13",
         "husky": "^8.0.3",
         "lint-staged": "^13.2.3",
+        "modern-css-reset": "^1.4.0",
         "prettier": "^3.0.0",
         "sst": "^2.22.10",
         "storybook": "^7.2.0",
@@ -20263,6 +20264,12 @@
       "dependencies": {
         "obliterator": "^2.0.1"
       }
+    },
+    "node_modules/modern-css-reset": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/modern-css-reset/-/modern-css-reset-1.4.0.tgz",
+      "integrity": "sha512-0crZmSFmrxkI7159rvQWjpDhy0u4+Awg/iOycJdlVn0RSeft/a+6BrQHR3IqvmdK25sqt0o6Z5Ap7cWgUee2rw==",
+      "dev": true
     },
     "node_modules/mqtt": {
       "version": "4.3.7",
@@ -41309,6 +41316,12 @@
       "requires": {
         "obliterator": "^2.0.1"
       }
+    },
+    "modern-css-reset": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/modern-css-reset/-/modern-css-reset-1.4.0.tgz",
+      "integrity": "sha512-0crZmSFmrxkI7159rvQWjpDhy0u4+Awg/iOycJdlVn0RSeft/a+6BrQHR3IqvmdK25sqt0o6Z5Ap7cWgUee2rw==",
+      "dev": true
     },
     "mqtt": {
       "version": "4.3.7",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "eslint-plugin-storybook": "^0.6.13",
     "husky": "^8.0.3",
     "lint-staged": "^13.2.3",
+    "modern-css-reset": "^1.4.0",
     "prettier": "^3.0.0",
     "sst": "^2.22.10",
     "storybook": "^7.2.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,5 @@
+import 'modern-css-reset/dist/reset.min.css';
+
 import type { Metadata } from 'next';
 import EmotionRegistry from '@/components/provider/Registry';
 import React from 'react';


### PR DESCRIPTION
## Ticket

- Github Issue: cuculus-dev/cuculus-roadmap/issues/9

## 変更内容
modern-css-resetの導入と設定

## 確認方法
`npm run dev`で立ち上げてローカルで確認した際、layout.cssとしてmodern-css-resetの内容が返却される

## Screenshot (任意)
