### PR TITLE
ヘッダーコンポーネントの作成 #3　LinkButton

### DIFF
--- a/src/components/header/LinkButton.tsx
+++ b/src/components/header/LinkButton.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { Button as MuiButton } from '@mui/material';
+
+interface ButtonProps {
+  variant: any;
+  href: string;
+  label: string;
+  size: any;
+  color: any;
+}
+
+export const Button = ({
+  variant,
+  href,
+  label,
+  size,
+  color,
+  ...args
+}: ButtonProps) => {
+  return (
+    <MuiButton
+      variant={variant}
+      href={href}
+      size={size}
+      color={color}
+      {...args}
+    >
+      {label}
+    </MuiButton>
+  );
+};


### PR DESCRIPTION
## Ticket

- Github Issue: cuculus-dev/cuculus-roadmap/issues/3

## 変更内容
LinkButtonを新規作成

## 確認方法
以下を挿入してボタンがロゴ（Cuculus）の横に表示されていること
「Header.tsx」const Headerのreturn内に追加
<Button
        variant={'contained'}
        href={'/'}
        label={'test'}
        size={'small'}
        color={'success'}
        disableElevation
      />

挿入したボタンの横に以下のボタンを追加し、sampleに遷移できることを確認
「Header.tsx」const Headerのreturn内に追加
<Button
        variant={'text'}
        href={'http://localhost:3000/sample'}
        label={'sample'}
        size={'medium'}
        color={'primary'}
      />

## Screenshot (任意)
![スクリーンショット 2023-08-13 202604](https://github.com/cuculus-dev/cuculus-roadmap/assets/140510343/161df97c-ea5e-40a6-b9a8-f3948b01b4ae)

![スクリーンショット 2023-08-13 203654](https://github.com/cuculus-dev/cuculus-roadmap/assets/140510343/2ee3b295-2725-4480-8cc0-c8ae88ebc432)
