### PR TITLE
バックグラウンドの修正とマイルストーンのサンプル実装

### DIFF
--- a/src/app/_components/MilestonesSample.tsx
+++ b/src/app/_components/MilestonesSample.tsx
@@ -6,10 +6,10 @@ import { useMilestones } from '@/swr/client/milestones';
  * マイルストーン取得サンプル
  * @constructor
  */
-const MilestoneSample = () => {
+const MilestonesSample = () => {
   const { data } = useMilestones();
   return (
-    <div>
+    <div style={{ padding: '16px' }}>
       {data ? (
         data.map((item, index) => (
           <div key={index}>
@@ -24,4 +24,4 @@ const MilestoneSample = () => {
   );
 };
 
-export default MilestoneSample;
+export default MilestonesSample;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,11 @@
 import Caption from '@/app/_components/Caption';
+import MilestonesSample from '@/app/_components/MilestonesSample';
 
 export default function Home() {
   return (
     <main>
       <Caption />
-      <div style={{ height: '1000px' }}>DUMMY</div>
+      <MilestonesSample />
     </main>
   );
 }

--- a/src/app/sample/page.tsx
+++ b/src/app/sample/page.tsx
@@ -1,9 +1,0 @@
-import MilestoneSample from '@/app/sample/_components/MilestonesSample';
-
-export default function Sample() {
-  return (
-    <main>
-      <MilestoneSample />
-    </main>
-  );
-}

--- a/src/components/layout/Background.tsx
+++ b/src/components/layout/Background.tsx
@@ -3,6 +3,7 @@
 import { styled } from '@mui/material/styles';
 
 const StyledBackground = styled('div')`
+  min-height: 100vh;
   background-color: #dcecfc;
   background-position: top center;
   background-size: 100% auto;


### PR DESCRIPTION
## Ticket
なし

## 変更内容
- バックグランドの`min-height`を`100vh`(画面幅)に
- `/sample`の削除
- マイルストーンのサンプルをトップページに移行

## 確認方法
localhostで確認

## Screenshot (任意)
